### PR TITLE
Added board .hasWon() and .isTie() methods

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,6 +19,17 @@ export enum Position {
   BottomRight = "bottom-right",
 }
 
+export enum WinningLine {
+  TopRow       = "top-row",
+  MiddleRow    = "middle-row",
+  BottomRow    = "bottom-row",
+  LeftColumn   = "left-column",
+  CenterColumn = "center-column",
+  RightColumn  = "right-column",
+  DownDiagonal = "down-diagonal",
+  UpDiagonal   = "up-diagonal",
+}
+
 //=================================================================================================
 // COMMANDS
 //=================================================================================================

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3,7 +3,8 @@ import { Board } from "./server"
 
 import {
   Piece,
-  Position
+  Position,
+  WinningLine
 } from "./interface"
 
 //-------------------------------------------------------------------------------------------------
@@ -35,6 +36,118 @@ test("place piece on board", () => {
   expect(board.isOccupied(Position.BottomLeft)).toEqual(Piece.Cross)
   expect(board.isOccupied(Position.Bottom)).toEqual(false)
   expect(board.isOccupied(Position.BottomRight)).toEqual(Piece.Dot)
+})
+
+//-------------------------------------------------------------------------------------------------
+
+test("board winning lines", () => {
+  const board = new Board()
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopLeft,  Piece.Cross)
+  board.place(Position.Top,      Piece.Cross)
+  board.place(Position.TopRight, Piece.Cross)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(WinningLine.TopRow)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.Left,   Piece.Dot)
+  board.place(Position.Center, Piece.Dot)
+  board.place(Position.Right,  Piece.Dot)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(WinningLine.MiddleRow)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.BottomLeft,  Piece.Cross)
+  board.place(Position.Bottom,      Piece.Cross)
+  board.place(Position.BottomRight, Piece.Cross)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(WinningLine.BottomRow)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopLeft,    Piece.Dot)
+  board.place(Position.Left,       Piece.Dot)
+  board.place(Position.BottomLeft, Piece.Dot)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(WinningLine.LeftColumn)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.Top,    Piece.Cross)
+  board.place(Position.Center, Piece.Cross)
+  board.place(Position.Bottom, Piece.Cross)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(WinningLine.CenterColumn)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopRight,    Piece.Dot)
+  board.place(Position.Right,       Piece.Dot)
+  board.place(Position.BottomRight, Piece.Dot)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(WinningLine.RightColumn)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopLeft,     Piece.Cross)
+  board.place(Position.Center,      Piece.Cross)
+  board.place(Position.BottomRight, Piece.Cross)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(WinningLine.DownDiagonal)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.BottomLeft, Piece.Dot)
+  board.place(Position.Center,     Piece.Dot)
+  board.place(Position.TopRight,   Piece.Dot)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(WinningLine.UpDiagonal)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopLeft,     Piece.Cross)
+  board.place(Position.Top,         Piece.Dot)
+  board.place(Position.TopRight,    Piece.Dot)
+  board.place(Position.Left,        Piece.Dot)
+  board.place(Position.Center,      Piece.Cross)
+  board.place(Position.Right,       Piece.Dot)
+  board.place(Position.BottomLeft,  Piece.Dot)
+  board.place(Position.Bottom,      Piece.Dot)
+  board.place(Position.BottomRight, Piece.Cross)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(WinningLine.DownDiagonal)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(false)
+
+  board.reset()
+  board.place(Position.TopLeft,     Piece.Cross)
+  board.place(Position.Top,         Piece.Dot)
+  board.place(Position.TopRight,    Piece.Cross)
+  board.place(Position.Left,        Piece.Dot)
+  board.place(Position.Center,      Piece.Cross)
+  board.place(Position.Right,       Piece.Dot)
+  board.place(Position.BottomLeft,  Piece.Dot)
+  board.place(Position.Bottom,      Piece.Cross)
+  board.place(Position.BottomRight, Piece.Dot)
+
+  expect(board.hasWon(Piece.Cross)).toEqual(false)
+  expect(board.hasWon(Piece.Dot)).toEqual(false)
+  expect(board.isTie()).toEqual(true)
 })
 
 //-------------------------------------------------------------------------------------------------

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { WebSocket, WebSocketServer } from "ws"
 import {
   Position,
   Piece,
+  WinningLine,
   Command,
   Event,
   AnyCommand,
@@ -60,6 +61,36 @@ export class Board {
 
   isOccupied(position: Position) {
     return this.cells[position] ?? false
+  }
+
+  hasWon(piece: Piece) {
+    if (this.cells[Position.TopLeft] === piece && this.cells[Position.Top] === piece && this.cells[Position.TopRight] === piece)
+      return WinningLine.TopRow
+    if (this.cells[Position.Left] === piece && this.cells[Position.Center] === piece && this.cells[Position.Right] === piece)
+      return WinningLine.MiddleRow
+    if (this.cells[Position.BottomLeft] === piece && this.cells[Position.Bottom] === piece && this.cells[Position.BottomRight] === piece)
+      return WinningLine.BottomRow
+    if (this.cells[Position.TopLeft] === piece && this.cells[Position.Left] === piece && this.cells[Position.BottomLeft] === piece)
+      return WinningLine.LeftColumn
+    if (this.cells[Position.Top] === piece && this.cells[Position.Center] === piece && this.cells[Position.Bottom] === piece)
+      return WinningLine.CenterColumn
+    if (this.cells[Position.TopRight] === piece && this.cells[Position.Right] === piece && this.cells[Position.BottomRight] === piece)
+      return WinningLine.RightColumn
+    if (this.cells[Position.TopLeft] === piece && this.cells[Position.Center] === piece && this.cells[Position.BottomRight] === piece)
+      return WinningLine.DownDiagonal
+    if (this.cells[Position.BottomLeft] === piece && this.cells[Position.Center] === piece && this.cells[Position.TopRight] === piece)
+      return WinningLine.UpDiagonal
+    return false
+  }
+
+  isFull() {
+    return Object.entries(this.cells).every(([_key, value]) => value !== undefined)
+  }
+
+  isTie() {
+    return this.isFull()
+      && !this.hasWon(Piece.Cross)
+      && !this.hasWon(Piece.Dot)
   }
 
 }


### PR DESCRIPTION
This PR adds `Board` `.hasWon()` and `.isTied()` methods. The former returns a `WinningLine` (enum) 