### PR TITLE
Implemented JoinCommand

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -30,34 +30,62 @@ export enum WinningLine {
   UpDiagonal   = "up-diagonal",
 }
 
+export enum PlayerState {
+  Joining     = "Joining",
+  WaitingGame = "WaitingGame",
+}
+
+//=================================================================================================
+// INTERFACES
+//=================================================================================================
+
+export interface Player {
+  state: PlayerState;
+  name: string;
+}
+
 //=================================================================================================
 // COMMANDS
 //=================================================================================================
 
 export enum Command {
   Ping = "Ping",
+  Join = "Join",
 }
 
 interface PingCommand {
   type: Command.Ping;
 }
 
+interface JoinCommand {
+  type: Command.Join;
+  name: string;
+}
+
 export type AnyCommand =
   | PingCommand
+  | JoinCommand
 
 //=================================================================================================
 // EVENTS
 //=================================================================================================
 
 export enum Event {
-  Pong = "Pong",
+  Pong        = "Pong",
+  PlayerReady = "PlayerReady",
 }
 
 export interface PongEvent {
   type: Event.Pong;
 }
 
+export interface PlayerReadyEvent {
+  type: Event.PlayerReady;
+  player: Player;
+}
+
 export type AnyEvent =
   | PongEvent
+  | PlayerReadyEvent
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements the `JoinCommand` which the client will send - along with their name - to join the lobby. It responds with the `PlayerReadyEvent`

  * Introduces the `PlayerState` enum
  * Adds a `Player.state` attribute
  * Adds a `Player.name` attribute
  * Adds a `MockClient` to the tests to collect the events for verification
