### PR TITLE
Automatically start new game when 2nd player joins

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -33,6 +33,8 @@ export enum WinningLine {
 export enum PlayerState {
   Joining     = "Joining",
   WaitingGame = "WaitingGame",
+  TakingTurn  = "TakingTurn",
+  WaitingTurn = "WaitingTurn",
 }
 
 //=================================================================================================
@@ -73,6 +75,7 @@ export type AnyCommand =
 export enum Event {
   Pong        = "Pong",
   PlayerReady = "PlayerReady",
+  GameStarted = "GameStarted",
 }
 
 export interface PongEvent {
@@ -84,8 +87,15 @@ export interface PlayerReadyEvent {
   player: Player;
 }
 
+export interface GameStartedEvent {
+  type: Event.GameStarted;
+  player: Player;
+  opponent: Player;
+}
+
 export type AnyEvent =
   | PongEvent
   | PlayerReadyEvent
+  | GameStartedEvent
 
 //-------------------------------------------------------------------------------------------------

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -205,12 +205,22 @@ test("2 players play a game, player1 wins", () => {
       type: Event.PlayerReady,
       player: { name: JAKE, state: PlayerState.WaitingGame }
     },
+    {
+      type: Event.GameStarted,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+    },
   ])
 
   expect(client2.events()).toEqual([
     {
       type: Event.PlayerReady,
       player: { name: AMY, state: PlayerState.WaitingGame }
+    },
+    {
+      type: Event.GameStarted,
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
     },
   ])
 


### PR DESCRIPTION
This PR ensures that a game starts when the 2nd player joins by finding a waiting opponent and sending a `GameStarted` event to both players.

Each player is assigned a `.board`, a `.opponent`, and a `.piece` and `PlayerState` is extended with 2 new values `TakingTurn` and `WaitingTurn`

We (arbitrarily) let the player that was waiting take the `Piece.Cross` and be the first `TakingTurn`