### PR TITLE
Implement TurnCommand, PlayerTookTurnEvent, and OpponentTookTurnEvent

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -53,6 +53,7 @@ export interface Player {
 export enum Command {
   Ping = "Ping",
   Join = "Join",
+  Turn = "Turn",
 }
 
 interface PingCommand {
@@ -64,18 +65,26 @@ interface JoinCommand {
   name: string;
 }
 
+interface TurnCommand {
+  type: Command.Turn;
+  position: Position;
+}
+
 export type AnyCommand =
   | PingCommand
   | JoinCommand
+  | TurnCommand
 
 //=================================================================================================
 // EVENTS
 //=================================================================================================
 
 export enum Event {
-  Pong        = "Pong",
-  PlayerReady = "PlayerReady",
-  GameStarted = "GameStarted",
+  Pong              = "Pong",
+  PlayerReady       = "PlayerReady",
+  GameStarted       = "GameStarted",
+  PlayerTookTurn    = "PlayerTookTurn",
+  OpponentTookTurn  = "OpponentTookTurn",
 }
 
 export interface PongEvent {
@@ -93,9 +102,25 @@ export interface GameStartedEvent {
   opponent: Player;
 }
 
+export interface PlayerTookTurnEvent {
+  type:     Event.PlayerTookTurn;
+  player:   Player;
+  opponent: Player;
+  position: Position;
+}
+
+export interface OpponentTookTurnEvent {
+  type:     Event.OpponentTookTurn;
+  player:   Player;
+  opponent: Player;
+  position: Position;
+}
+
 export type AnyEvent =
   | PongEvent
   | PlayerReadyEvent
   | GameStartedEvent
+  | PlayerTookTurnEvent
+  | OpponentTookTurnEvent
 
 //-------------------------------------------------------------------------------------------------

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -199,6 +199,11 @@ test("2 players play a game, player1 wins", () => {
 
   lobby.execute(player1, { type: Command.Join, name: JAKE })
   lobby.execute(player2, { type: Command.Join, name: AMY  })
+  lobby.execute(player1, { type: Command.Turn, position: Position.Center   })
+  lobby.execute(player2, { type: Command.Turn, position: Position.TopLeft  })
+  lobby.execute(player1, { type: Command.Turn, position: Position.Left     })
+  lobby.execute(player2, { type: Command.Turn, position: Position.TopRight })
+  lobby.execute(player1, { type: Command.Turn, position: Position.Right    })
 
   expect(client1.events()).toEqual([
     {
@@ -209,6 +214,36 @@ test("2 players play a game, player1 wins", () => {
       type: Event.GameStarted,
       player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
       opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+    },
+    {
+      type: Event.PlayerTookTurn,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      position: Position.Center,
+    },
+    {
+      type: Event.OpponentTookTurn,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+      position: Position.TopLeft,
+    },
+    {
+      type: Event.PlayerTookTurn,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      position: Position.Left,
+    },
+    {
+      type: Event.OpponentTookTurn,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+      position: Position.TopRight,
+    },
+    {
+      type: Event.PlayerTookTurn,
+      player:   { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      opponent: { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      position: Position.Right,
     },
   ])
 
@@ -221,6 +256,36 @@ test("2 players play a game, player1 wins", () => {
       type: Event.GameStarted,
       player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
       opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+    },
+    {
+      type: Event.OpponentTookTurn,
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      position: Position.Center,
+    },
+    {
+      type: Event.PlayerTookTurn,
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+      position: Position.TopLeft,
+    },
+    {
+      type: Event.OpponentTookTurn,
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      position: Position.Left,
+    },
+    {
+      type: Event.PlayerTookTurn,
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.WaitingTurn },
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.TakingTurn  },
+      position: Position.TopRight,
+    },
+    {
+      type: Event.OpponentTookTurn,
+      opponent: { name: JAKE, piece: Piece.Cross, state: PlayerState.WaitingTurn },
+      player:   { name: AMY,  piece: Piece.Dot,   state: PlayerState.TakingTurn  },
+      position: Position.Right,
     },
   ])
 


### PR DESCRIPTION
This PR allows players to take turns by implementing the `TurnCommand` and the corresponding `PlayerTookTurnEvent` and `OpponentTookTurnEvent`.

> NOTE: no error handling yet, no win/lose/tie end state yet