### PR TITLE
update header and board UX when new game starts

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,15 @@
         Hi
         <span class="header-player-name"></span>
       </h1>
+      <h2 class="header-opponent hidden">
+        You&nbsp;are
+        <ttt-dot class="header-player-dot hidden"></ttt-dot>
+        <ttt-cross class="header-player-cross hidden"></ttt-cross>
+        vs
+        <ttt-dot class="header-opponent-dot hidden"></ttt-dot>
+        <ttt-cross class="header-opponent-cross hidden"></ttt-cross>
+        <span class="header-opponent-name"></span>
+      </h2>
       <h3 class="header-status"></h3>
     </div>
   </template>

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,5 +1,16 @@
-export const assert = {
+import { Piece } from "./interface"
+
+export const assert: {
+  unreachable: (arg: never) => never;
+  isPiece: (value: Piece | undefined) => asserts value is Piece;
+} = {
+
   unreachable: (_arg: never): never => {
     throw new Error("unreachable")
   },
+
+  isPiece: (value: Piece | undefined): asserts value is Piece => {
+    if (value === undefined)
+      throw new Error("value is undefined")
+  }
 }

--- a/src/client.css
+++ b/src/client.css
@@ -167,17 +167,28 @@ button:focus {
   gap: var(--spacing-1);
 }
 
-.header-player {
+.header-player,
+.header-opponent {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
 }
 
-.header-player-name {
+.header-player-name,
+.header-opponent-name {
   font-weight: var(--font-bold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.header-player-dot,
+.header-player-cross,
+.header-opponent-dot,
+.header-opponent-cross {
+  width: var(--spacing-4);
+  margin-top: var(--spacing-1);
+  flex-shrink: 0;
 }
 
 /**************************************************************************************************
@@ -209,6 +220,21 @@ button:focus {
 .board-cell       ttt-cross { display: none; width: 60%; margin-top: 5px; }
 .board-cell.dot   ttt-dot   { display: block; }
 .board-cell.cross ttt-cross { display: block; }
+
+.board.cross.my-turn .board-cell:not(.dot):not(.cross):hover {
+  background-color: color-mix(in srgb, var(--cross-color) 10%, white);
+  cursor: pointer;
+}
+
+.board.dot.my-turn .board-cell:not(.dot):not(.cross):hover {
+  background-color: color-mix(in srgb, var(--dot-color) 10%, white);
+  cursor: pointer;
+}
+
+.board.my-turn .board-cell.dot:hover,
+.board.my-turn .board-cell.cross:hover {
+  cursor: not-allowed;
+}
 
 /**************************************************************************************************
  UTILITIES

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import { Header, JoinEvent } from "./client/header"
 import { Board, Dot, Cross } from "./client/board"
 
 import {
+  PlayerState,
   Command,
   AnyCommand,
   Event,
@@ -63,8 +64,10 @@ class Game {
     this.header.reset(player)
   }
 
-  onGameStarted(event: GameStartedEvent) {
-    console.log("TODO", event)
+  onGameStarted({ player, opponent }: GameStartedEvent) {
+    assert.isPiece(player.piece)
+    this.header.start(player, opponent)
+    this.board.start(player.piece, player.state === PlayerState.TakingTurn)
   }
 
   onPlayerTookTurn(event: PlayerTookTurnEvent) {

--- a/src/client/board.ts
+++ b/src/client/board.ts
@@ -1,4 +1,6 @@
-import { Position } from "../interface"
+import { Piece, Position } from "../interface"
+
+const MY_TURN = "my-turn"
 
 export class Board extends HTMLElement {
   board: HTMLElement
@@ -21,6 +23,14 @@ export class Board extends HTMLElement {
       [Position.Bottom]:      this.querySelector(".board-cell.bottom")       as HTMLElement,
       [Position.BottomRight]: this.querySelector(".board-cell.bottom-right") as HTMLElement,
     }
+  }
+
+  start(piece: Piece, myTurn: boolean) {
+    this.board.classList.add(piece)
+    if (myTurn)
+      this.board.classList.add(MY_TURN)
+    else
+      this.board.classList.remove(MY_TURN)
   }
 }
 

--- a/src/client/header.ts
+++ b/src/client/header.ts
@@ -1,5 +1,5 @@
 import { assert } from "../assert"
-import { Player, PlayerState } from "../interface"
+import { Piece, Player, PlayerState } from "../interface"
 import { show, hide } from "../client"
 
 export class JoinEvent extends CustomEvent<{ name: string }> {}
@@ -27,10 +27,17 @@ export class Header extends HTMLElement {
     this.nameInput.removeEventListener("input", this)
   }
 
-  get nameInput()  { return this.querySelector(".header-name-input") as HTMLInputElement }
-  get joinButton() { return this.querySelector(".header-join-button") as HTMLButtonElement }
-  get status()     { return this.querySelector(".header-status") as HTMLElement  }
-  get playerName() { return this.querySelector(".header-player-name") as HTMLElement }
+  get nameInput()     { return this.querySelector(".header-name-input") as HTMLInputElement }
+  get joinButton()    { return this.querySelector(".header-join-button") as HTMLButtonElement }
+  get status()        { return this.querySelector(".header-status") as HTMLElement  }
+  get opponent()      { return this.querySelector(".header-opponent") as HTMLElement }
+  get playerName()    { return this.querySelector(".header-player-name") as HTMLElement }
+  get playerDot()     { return this.querySelector(".header-player-dot") as HTMLElement }
+  get playerCross()   { return this.querySelector(".header-player-cross") as HTMLElement }
+  get opponentName()  { return this.querySelector(".header-opponent-name") as HTMLElement }
+  get opponentDot()   { return this.querySelector(".header-opponent-dot") as HTMLElement }
+  get opponentCross() { return this.querySelector(".header-opponent-cross") as HTMLElement }
+  get replayButton()  { return this.querySelector(".header-replay-button") as HTMLButtonElement }
 
   handleEvent(event: Event) {
     switch (event.type) {
@@ -46,8 +53,19 @@ export class Header extends HTMLElement {
 
   reset(player: Player) {
     hide(this.form)
+    hide(this.opponent)
     show(this.details)
     this.playerName.innerText = player.name
+    this.update(player)
+  }
+
+  start(player: Player, opponent: Player) {
+    show(this.opponent)
+    show(this.playerCross, player.piece === Piece.Cross)
+    show(this.playerDot, player.piece === Piece.Dot)
+    show(this.opponentCross, opponent.piece === Piece.Cross)
+    show(this.opponentDot, opponent.piece === Piece.Dot)
+    this.opponentName.innerText = opponent.name
     this.update(player)
   }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -55,6 +55,7 @@ export enum UnexpectedError {
 export interface Player {
   state: PlayerState;
   name: string;
+  piece?: Piece;
 }
 
 //=================================================================================================


### PR DESCRIPTION
This PR updates the header and board UX after a `GameStartedEvent`
 
  * The header shows the players piece, and the opponent name
  * The board activates a hover state for the player whose turn it is (via the `my-turn` css class)