### PR TITLE
added click event to board to send TurnCommand

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,10 @@
 import topbar from "topbar"
 import { assert } from "./assert"
 import { Header, JoinEvent } from "./client/header"
-import { Board, Dot, Cross } from "./client/board"
+import { Board, Dot, Cross, TurnEvent } from "./client/board"
 
 import {
+  Position,
   PlayerState,
   Command,
   AnyCommand,
@@ -50,6 +51,7 @@ class Game {
     this.header = document.getElementById("header") as Header
     this.board  = document.getElementById("board")  as Board
     this.header.addEventListener("join", (ev) => this.onJoin((ev as JoinEvent).detail.name))
+    this.board.addEventListener("turn", (ev) => this.onTurn((ev as TurnEvent).detail.position))
   }
 
   onPong(event: PongEvent) {
@@ -70,12 +72,20 @@ class Game {
     this.board.start(player.piece, player.state === PlayerState.TakingTurn)
   }
 
-  onPlayerTookTurn(event: PlayerTookTurnEvent) {
-    console.log("TODO", event)
+  onTurn(position: Position) {
+    this.send({ type: Command.Turn, position })
   }
 
-  onOpponentTookTurn(event: OpponentTookTurnEvent) {
-    console.log("TODO", event)
+  onPlayerTookTurn({ player, position }: PlayerTookTurnEvent) {
+    assert.isPiece(player.piece)
+    this.board.set(position, player.piece, false)
+    this.header.update(player)
+  }
+
+  onOpponentTookTurn({ player, opponent, position }: OpponentTookTurnEvent) {
+    assert.isPiece(opponent.piece)
+    this.board.set(position, opponent.piece, true)
+    this.header.update(player)
   }
 
   onOpponentAbandoned(event: OpponentAbandonedEvent) {

--- a/src/client/board.ts
+++ b/src/client/board.ts
@@ -2,6 +2,8 @@ import { Piece, Position } from "../interface"
 
 const MY_TURN = "my-turn"
 
+export class TurnEvent extends CustomEvent<{ position: Position }> {}
+
 export class Board extends HTMLElement {
   board: HTMLElement
   cells: Record<Position, HTMLElement>
@@ -23,10 +25,30 @@ export class Board extends HTMLElement {
       [Position.Bottom]:      this.querySelector(".board-cell.bottom")       as HTMLElement,
       [Position.BottomRight]: this.querySelector(".board-cell.bottom-right") as HTMLElement,
     }
+
+    for (const [position, cell] of Object.entries(this.cells)) {
+      cell.addEventListener("click", () => {
+        if (this.board.classList.contains(MY_TURN) && !cell.classList.contains(Piece.Dot) && !cell.classList.contains(Piece.Cross)) {
+          this.dispatchEvent(new TurnEvent("turn", {
+            detail: {
+              position: position as Position,
+            },
+          }))
+        }
+      })
+    }
   }
 
   start(piece: Piece, myTurn: boolean) {
     this.board.classList.add(piece)
+    if (myTurn)
+      this.board.classList.add(MY_TURN)
+    else
+      this.board.classList.remove(MY_TURN)
+  }
+
+  set(position: Position, piece: Piece, myTurn: boolean) {
+    this.cells[position].classList.add(piece)
     if (myTurn)
       this.board.classList.add(MY_TURN)
     else


### PR DESCRIPTION
This PR adds a click event handler to the `Board` and sends a `TurnCommand` to the server. It also adds handlers for the `PlayerTookTurn` and `OpponentTookTurn` events to show the appropriate piece on the board (by setting the appropriate css classname)