### PR TITLE
Show winning lines after player wins or loses

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,15 @@
   <template id="ttt-board">
     <div class="board">
 
+      <div class="winning-line top-row"></div>
+      <div class="winning-line middle-row"></div>
+      <div class="winning-line bottom-row"></div>
+      <div class="winning-line left-column"></div>
+      <div class="winning-line center-column"></div>
+      <div class="winning-line right-column"></div>
+      <div class="winning-line down-diagonal"></div>
+      <div class="winning-line up-diagonal"></div>
+
       <div class="board-row">
         <div class="board-cell top-left">
           <ttt-dot></ttt-dot>

--- a/src/client.css
+++ b/src/client.css
@@ -236,6 +236,74 @@ button:focus {
   cursor: not-allowed;
 }
 
+.winning-line {
+  display: none;
+  position: absolute;
+  border-radius: 1000px;
+  opacity: 50%;
+}
+
+.winning-line.cross { display: block; background-color: var(--cross-color);  }
+.winning-line.dot   { display: block; background-color: var(--dot-color);    }
+
+.winning-line.top-row {
+  left: 5%;
+  right: 5%;
+  top: calc(((100% - (2 * var(--board-gap))) * 1/6) - (var(--board-win-thickness)/2));
+  height: var(--board-win-thickness);
+}
+
+.winning-line.middle-row {
+  left: 5%;
+  right: 5%;
+  top: calc(50% - (var(--board-win-thickness)/2));
+  height: var(--board-win-thickness);
+}
+
+.winning-line.bottom-row {
+  left: 5%;
+  right: 5%;
+  bottom: calc(((100% - (2 * var(--board-gap))) * 1/6) - (var(--board-win-thickness)/2));
+  height: var(--board-win-thickness);
+}
+
+.winning-line.left-column {
+  top: 5%;
+  bottom: 5%;
+  left: calc(((100% - (2 * var(--board-gap))) * 1/6) - (var(--board-win-thickness)/2));
+  width: var(--board-win-thickness);
+}
+
+.winning-line.center-column {
+  top: 5%;
+  bottom: 5%;
+  left: calc(50% - (var(--board-win-thickness)/2));
+  width: var(--board-win-thickness);
+}
+
+.winning-line.right-column {
+  top: 5%;
+  bottom: 5%;
+  right: calc(((100% - (2 * var(--board-gap))) * 1/6) - (var(--board-win-thickness)/2));
+  width: var(--board-win-thickness);
+}
+
+.winning-line.down-diagonal {
+  left: calc(((90% * sqrt(2)) - 100%) * -1/2);
+  width: calc(90% * sqrt(2));
+  top: calc(50% - (var(--board-win-thickness)/2));
+  height: var(--board-win-thickness);
+  transform: rotate(45deg);
+}
+
+.winning-line.up-diagonal {
+  left: calc(((90% * sqrt(2)) - 100%) * -1/2);
+  width: calc(90% * sqrt(2));
+  top: calc(50% - (var(--board-win-thickness)/2));
+  height: var(--board-win-thickness);
+  transform: rotate(-45deg);
+}
+
 /**************************************************************************************************
  UTILITIES
  **************************************************************************************************/

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,16 +92,20 @@ class Game {
     console.log("TODO", event)
   }
 
-  onPlayerWon(event: PlayerWonEvent) {
-    console.log("TODO", event)
+  onPlayerWon({ player, line }: PlayerWonEvent) {
+    assert.isPiece(player.piece)
+    this.board.win(line, player.piece)
+    this.header.end(player)
   }
 
-  onPlayerLost(event: PlayerLostEvent) {
-    console.log("TODO", event)
+  onPlayerLost({ player, opponent, line }: PlayerLostEvent) {
+    assert.isPiece(opponent.piece)
+    this.board.win(line, opponent.piece)
+    this.header.end(player)
   }
 
-  onPlayerTied(event: PlayerTiedEvent) {
-    console.log("TODO", event)
+  onPlayerTied({ player }: PlayerTiedEvent) {
+    this.header.end(player)
   }
 
   onError(error: UnexpectedError) {

--- a/src/client/board.ts
+++ b/src/client/board.ts
@@ -1,4 +1,4 @@
-import { Piece, Position } from "../interface"
+import { Piece, Position, WinningLine } from "../interface"
 
 const MY_TURN = "my-turn"
 
@@ -7,6 +7,7 @@ export class TurnEvent extends CustomEvent<{ position: Position }> {}
 export class Board extends HTMLElement {
   board: HTMLElement
   cells: Record<Position, HTMLElement>
+  winningLines: Record<WinningLine, HTMLElement>
 
   constructor() {
     super()
@@ -24,6 +25,17 @@ export class Board extends HTMLElement {
       [Position.BottomLeft]:  this.querySelector(".board-cell.bottom-left")  as HTMLElement,
       [Position.Bottom]:      this.querySelector(".board-cell.bottom")       as HTMLElement,
       [Position.BottomRight]: this.querySelector(".board-cell.bottom-right") as HTMLElement,
+    }
+
+    this.winningLines = {
+      [WinningLine.TopRow]:       this.querySelector(".winning-line.top-row")       as HTMLElement,
+      [WinningLine.MiddleRow]:    this.querySelector(".winning-line.middle-row")    as HTMLElement,
+      [WinningLine.BottomRow]:    this.querySelector(".winning-line.bottom-row")    as HTMLElement,
+      [WinningLine.LeftColumn]:   this.querySelector(".winning-line.left-column")   as HTMLElement,
+      [WinningLine.CenterColumn]: this.querySelector(".winning-line.center-column") as HTMLElement,
+      [WinningLine.RightColumn]:  this.querySelector(".winning-line.right-column")  as HTMLElement,
+      [WinningLine.DownDiagonal]: this.querySelector(".winning-line.down-diagonal") as HTMLElement,
+      [WinningLine.UpDiagonal]:   this.querySelector(".winning-line.up-diagonal")   as HTMLElement,
     }
 
     for (const [position, cell] of Object.entries(this.cells)) {
@@ -53,6 +65,11 @@ export class Board extends HTMLElement {
       this.board.classList.add(MY_TURN)
     else
       this.board.classList.remove(MY_TURN)
+  }
+
+  win(line: WinningLine, piece: Piece) {
+    this.winningLines[line].classList.add(piece)
+    this.board.classList.remove(MY_TURN)
   }
 }
 

--- a/src/client/header.ts
+++ b/src/client/header.ts
@@ -73,6 +73,10 @@ export class Header extends HTMLElement {
     this.status.innerText = this.statusLabel(player)
   }
 
+  end(player: Player) {
+    this.update(player)
+  }
+
   private statusLabel(player: Player) {
     switch (player.state) {
     case PlayerState.Joining:     return "Joining game..."


### PR DESCRIPTION
This PR adds UX to show winning lines in response to `PlayerWonEvent` or `PlayerLostEvent`. It also updates the header message in response to `PlayerTiedEvent`

We are using CSS absolutely positioned elements via `calc()` to show the winning lines in the correct position and orientation