### PR TITLE
switch between ws: and wss: websocket protocol

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -176,6 +176,7 @@ function connect(url: string): Promise<Game> {
   })
 }
 
-await connect(`ws://${location.host}/ws`)
+const protocol = location.protocol === "https:" ? "wss" : "ws"
+await connect(`${protocol}://${location.host}/ws`)
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR ensures that the websocket client connects to the server using `wss:` protocol (instead of `ws:`) if the page is hosted on `https:` protocol (vs `http:`)