### PR TITLE
Fix broken npm run build

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,6 +20,6 @@ jobs:
         node-version: '21.4.0'
         cache: 'npm'
     - run: npm ci
-    # - run: npm run build --if-present
+    - run: npm run build --if-present
     - run: npm run test
     - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
-        "dedent": "^1.5.1",
         "eslint": "^8.56.0",
         "eslint-plugin-html": "^7.1.0",
         "npm-run-all": "^4.1.5",
@@ -1386,20 +1385,6 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "dev": true,
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
           "optional": true
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "strict": true,
     "strictNullChecks": true,
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": true
   },
   "include": [
     ".eslintrc.cjs",


### PR DESCRIPTION
This PR fixes the `npm run build` command by working around the [upstream issue]( https://github.com/vitejs/vite/issues/15714) via `skipLibCheck: true`