### PR TITLE
Respect PORT env variable so we can deploy to render

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -301,9 +301,10 @@ export class Lobby {
 // WEB SOCKET SERVER
 //=================================================================================================
 
-const port  = parseInt(process.env.SERVER_PORT ?? process.env.PORT ?? "3001")
-const wss   = new WebSocketServer({ port })
-const lobby = new Lobby()
+const clientPort = parseInt(process.env.PORT ?? process.env.CLIENT_PORT ?? "3000")
+const serverPort = parseInt(process.env.SERVER_PORT ?? `${clientPort+1}`)
+const wss        = new WebSocketServer({ port: serverPort })
+const lobby      = new Lobby()
 
 wss.on("connection", (ws: WebSocket) => {
 
@@ -339,7 +340,7 @@ wss.on("connection", (ws: WebSocket) => {
   })
 })
 
-console.log("LISTENING ON PORT: ", port)
+console.log("LISTENING ON PORT: ", serverPort)
 
 //-------------------------------------------------------------------------------------------------
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "vite"
 
-const clientPort = parseInt(process.env.CLIENT_PORT ?? "3000")
-const clientHost = process.env.CLIENT_HOST ?? "localhost"
-const serverPort = parseInt(process.env.SERVER_PORT ?? "3001")
+const clientPort = parseInt(process.env.PORT ?? process.env.CLIENT_PORT ?? "3000")
+const clientHost = process.env.HOST ?? process.env.CLIENT_HOST ?? "localhost"
+const serverPort = parseInt(process.env.SERVER_PORT ?? `${clientPort+1}`)
 const serverHost = process.env.SERVER_HOST ?? "localhost"
 
 export default defineConfig({


### PR DESCRIPTION
This PR ensures that we respect the Render deploy environment variables so we can use `PORT` for the client (and the server defaults to client port + 1)